### PR TITLE
Add Website Redesign Initiative example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create a new `.sh` file in this directory to hold your meeting configuration:
 touch ~/.make-node-meeting/<meetingname>.sh # Where <meetingname> is the name of the group or WG you want to create a meeting for.
 ```
 
-Once this file is created, open it in your editor of choice add a configuration. There are several [example configurations](./exmaples) in this repo.
+Once this file is created, open it in your editor of choice add a configuration. There are several [example configurations](./examples) in this repo.
 
 When the configuration is added, run the following command:
 ```

--- a/examples/wr.sh
+++ b/examples/wr.sh
@@ -1,0 +1,30 @@
+GROUP_NAME="Website Redesign Initiative"
+MEETING_TIME="Thursday 3:00pm"
+INVITEES="
+* @oe - Olivia Hugger
+* @fhemberger - Frederic Hemberger
+* @bnb - Tierney Cyren
+* @timothyis - Timothy
+* @jestho - Jesper Thøgersen
+* @JonahMoses - Jonah Moses
+* @amiller-gh - Adam Miller
+* @skllcrn - Christopher Skillicorn
+* @pierreneter - Pierre Neter
+* @emilypmendez - Emily Mendez
+* @darcyclarke - Darcy Clarke
+* @maddhruv - Dhruv Jain
+* @obensource - Ben Michel
+* @Fishrock123 - Jeremiah Senkpiel
+* @chowdhurian - Manil Chowdhury
+* @franciscop - Francisco Presencia
+"
+JOINING_INSTRUCTIONS="Zoom Meeting; a link will be posted here in the comments shortly before the meeting starts.
+
+If you're interested in joining the meeting, just open an issue in this repository to request an invite.
+
+## Public participation
+
+We stream our conference call straight to YouTube. Anyone can listen to it live. When we turn it on, it should start playing at https://www.youtube.com/channel/UCQPYJluYC_sn_Qz_XE-YbTQ/live. There's a short cat-herding time at the beginning of the meeting and, occasionally, we attend to some quick private business before we can start recording & streaming. Please be patient and the live stream should show up!
+
+Welcome to the Website Redesign Initiative! 💛
+"


### PR DESCRIPTION
Adds a script for the Website Redesign Initiative and fixes a link in the README.md

(The script name is taken from the existing naming of the agenda items label, namely `wr-agenda`)