### PR TITLE
Allow support for orgs other than nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ INVITEES="Markdown list of invitees"
 JOINING_INSTRUCTIONS="Specific instructions on how to join"
 ```
 
+The configuration file can optionally contain:
+
+```sh
+GITHUB_ORG="openjs-foundation"
+HOST="OpenJS Foundation"
+```
+
 The `MEETING_TIME` is used to work out _when the next meeting should occur_ and print that date and time accordingly, with translations to various world timezomes.
 
 For example, `~/.make-node-meeting/ctc.sh` might contain:

--- a/examples/bootstrap.sh
+++ b/examples/bootstrap.sh
@@ -1,0 +1,8 @@
+GITHUB_ORG="openjs-foundation"
+HOST="OpenJS Foundation"
+GROUP_NAME="Bootstrap Team"
+JOINING_INSTRUCTIONS="* link for participants: https://zoom.us/j/779273015
+* For those who just want to watch: https://www.youtube.com/c/nodejs+foundation/live"
+MEETING_TIME="2019-04-01T13:00:00.000Z"
+INVITEES="* OpenJS Foundation Project Maintainers
+* OpenJS Foundation Board of Directors"

--- a/make-node-meeting.sh
+++ b/make-node-meeting.sh
@@ -42,6 +42,14 @@ if [ "X${GROUP_NAME}" == "X" ] || [ "X${MEETING_TIME}" == "X" ] || [ "X${INVITEE
   print_usage_and_exit
 fi
 
+if [ "X${GITHUB_ORG}" == "X" ]; then
+  GITHUB_ORG=nodejs
+fi
+
+if [ "X${HOST}" == "X" ]; then
+  HOST="Node.js Foundation"
+fi
+
 meeting_date=$(TZ=UTC date --date="$MEETING_TIME" --rfc-3339=seconds)
 common_fmt="%a %d-%b-%Y %R (%I:%M %p)"
 utc_short=$(TZ=UTC date --date="$meeting_date" +"%F")
@@ -53,7 +61,7 @@ read curr_doc_url
 
 cat << EOF
 
-Node.js Foundation $GROUP_NAME Meeting $utc_short
+$HOST $GROUP_NAME Meeting $utc_short
 
 --------------------------------------
 
@@ -86,9 +94,9 @@ Or in your local time:
 
 ## Agenda
 
-Extracted from **${GROUP_CODE}-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+Extracted from **${GROUP_CODE}-agenda** labelled issues and pull requests from the **${GITHUB_ORG} org** prior to the meeting.
 
-`node ${__dirname}/node-meeting-agenda.js ${GROUP_CODE}-agenda`
+`node ${__dirname}/node-meeting-agenda.js ${GROUP_CODE}-agenda ${GITHUB_ORG}`
 
 ## Invited
 
@@ -96,7 +104,7 @@ $INVITEES
 
 ## Notes
 
-The agenda comes from issues labelled with \`${GROUP_CODE}-agenda\` across **all of the repositories in the nodejs org**. Please label any additional issues that should be on the agenda before the meeting starts.
+The agenda comes from issues labelled with \`${GROUP_CODE}-agenda\` across **all of the repositories in the ${GITHUB_ORG} org**. Please label any additional issues that should be on the agenda before the meeting starts.
 
 ## Joining the meeting
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "make-node-meeting": "./make-node-meeting.sh"
   },
   "dependencies": {
-    "node-meeting-agenda": "~1.0.4"
+    "node-meeting-agenda": "^1.0.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Relies on https://github.com/nodejs/node-meeting-agenda/pull/1

Should be a no-op without the dependency update