### PR TITLE
Update European timezones

### DIFF
--- a/make-node-meeting.sh
+++ b/make-node-meeting.sh
@@ -75,8 +75,9 @@ $HOST $GROUP_NAME Meeting $utc_short
 | US / Mountain | $(TZ=US/Mountain date --date="$meeting_date" +"$common_fmt") |
 | US / Central  | $(TZ=US/Central date --date="$meeting_date" +"$common_fmt") |
 | US / Eastern  | $(TZ=US/Eastern date --date="$meeting_date" +"$common_fmt") |
-| London        | $(TZ=Europe/London date --date="$meeting_date" +"$common_fmt") |
-| Amsterdam     | $(TZ=Europe/Amsterdam date --date="$meeting_date" +"$common_fmt") |
+| EU / Western  | $(TZ=Europe/London date --date="$meeting_date" +"$common_fmt") |
+| EU / Central  | $(TZ=Europe/Amsterdam date --date="$meeting_date" +"$common_fmt") |
+| EU / Eastern  | $(TZ=Europe/Helsinki date --date="$meeting_date" +"$common_fmt") |
 | Moscow        | $(TZ=Europe/Moscow date --date="$meeting_date" +"$common_fmt") |
 | Chennai       | $(TZ=Asia/Kolkata date --date="$meeting_date" +"$common_fmt") |
 | Hangzhou      | $(TZ=Asia/Shanghai date --date="$meeting_date" +"$common_fmt") |


### PR DESCRIPTION
This updates the European timezones to also include Eastern Europe, and renames them according to the same pattern used for North American timezones.